### PR TITLE
fix: customize the default theme, override text-align to avoid long indentations

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,0 +1,3 @@
+.post-content {
+    text-align: left;
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,2 @@
+{{ $customCSS := resources.Get "scss/custom.scss" | resources.ToCSS }}
+<link rel="stylesheet" href="{{ $customCSS.Permalink }}">


### PR DESCRIPTION
Hello,

Goal:
Avoid long indentations when backquotes are used one the same line as a sentence.

Default theme:

1. `assets/scss/_single.scss` is loaded by `assets/scss/main.scss`.
2. `assets/scss/main.scss` is loaded by `layouts/partials/head.html`

Duplicate the default theme directory structure to override text-align.